### PR TITLE
Fix missing XML documentation

### DIFF
--- a/Mailosaur/Mailosaur.csproj
+++ b/Mailosaur/Mailosaur.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
-    <PackageVersion>5.0.2.0</PackageVersion>
-    <AssemblyVersion>5.0.2.0</AssemblyVersion>
+    <PackageVersion>5.0.3.0</PackageVersion>
+    <AssemblyVersion>5.0.3.0</AssemblyVersion>
     <Authors>Mailosaur Ltd</Authors>
     <Owners>Mailosaur Ltd</Owners>
     <Title>Mailosaur .Net Client Library</Title>
@@ -14,7 +14,7 @@ Mailosaur allows you to automate tests that require email. You can use it with t
 You can also use it for manual testing as it gives you unlimited test email addresses or use it as a fake/dummy SMTP service.
 
 For more info go to mailosaur.com</Description>
-    <ReleaseVersion>5.0.2</ReleaseVersion>
+    <ReleaseVersion>5.0.3</ReleaseVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <PackageId>Mailosaur</PackageId>
     <PackageIconUrl>https://avatars0.githubusercontent.com/u/3448774?v=3&amp;amp;s=400</PackageIconUrl>
@@ -22,6 +22,7 @@ For more info go to mailosaur.com</Description>
     <PackageProjectUrl>https://github.com/mailosaur/mailosaur-dotnet</PackageProjectUrl>
     <Summary>Mailosaur allows you to automate email testing</Summary>
     <PackageTags>email automation api integration testing nunit mstest xunit selenium</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The XML documentation is not being published as part of the NuGet package.

For example, `MailosaurClient.Messages` contains the following doc:

```
/// <summary>
/// Gets the IMessages.
/// </summary>
```

However, on a fresh install of Mailosaur 5.0.2, the doc is not available:

![image](https://user-images.githubusercontent.com/6626631/53848152-1dc35500-3f68-11e9-8525-9d4168fde1bb.png)

Similarly, the documentation help text is missing for `SearchAsync` in the above screenshot, as well as every method/property/class in the library.

### Cause

I believe this is because https://github.com/mailosaur/mailosaur-dotnet/blob/master/Mailosaur/Mailosaur.csproj is missing `<GenerateDocumentationFile>true</GenerateDocumentationFile>`. By default, NuGet packages (such as those created by `dotnet pack`) are published without including the docs. I've filed a PR to fix, but I'll need help from people who are familiar with the CI chain to test.