### PR TITLE
fixing incorrect test assertions

### DIFF
--- a/Mailosaur.Test/EmailsTests.cs
+++ b/Mailosaur.Test/EmailsTests.cs
@@ -277,7 +277,7 @@ namespace Mailosaur.Test
             Assert.NotNull(file2.Id);
             Assert.Equal(212080, file2.Length);
             Assert.NotNull(file2.Url);
-            Assert.Equal("Resources/dog.png", file2.FileName);
+            Assert.Equal("dog.png", file2.FileName);
             Assert.Equal("image/png", file2.ContentType);
         }
     }


### PR DESCRIPTION
these files are stored in the project as Resources/dog.png
But come across in the server as just dog.png, which makes sense.  

Don't know if this was a recent change in the Mailosaur spec and attachments previously came over with directory names, but these tests failing prevent any other pull requests from going through